### PR TITLE
docs: Adiciona versão de Node.js compatível

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Esse exemplo é opinativo e segue uma estrutura que mescla diferentes recomenda�
 ## 📚 Tecnologias
 
 As tecnologias e estruturas utilizadas no exemplo são:
+- Node.js v16.15.0 LTS
 - Renderização com React 17;
 - Estrutura de pastas pronta para aplicação de médio porte;
 - Estilização com SASS e/ou styled-components;


### PR DESCRIPTION
Tentei rodar com o Node.js 18.2.0 que é a versão sem suporte de longo prazo e obtive um erro de compilação de SASS. Ao trocar para a versão 16.15.0 LTS o projeto funcionou corretamente. Por isto a proposição de adicionar a versão LTS mais recente funcional à documentação.